### PR TITLE
[MERGE] CORS Error & 로그인 Front 연동

### DIFF
--- a/src/main/java/com/wordwise/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/wordwise/common/config/WebSecurityConfig.java
@@ -39,8 +39,8 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/",
-                                "api/v1/auth/kakao/logintest",
-                                "api/v1/auth/kakao/login",
+                                "/api/v1/auth/kakao/logintest",
+                                "/api/v1/auth/kakao/login",
                                 "/api/v1/auth/kakao"
                         )
                         .permitAll()

--- a/src/main/java/com/wordwise/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/wordwise/domain/auth/controller/AuthController.java
@@ -13,6 +13,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@CrossOrigin(origins = "http://localhost:3000")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -35,7 +36,8 @@ public class AuthController {
     @PostMapping(value = "/v1/auth/kakao/login", consumes = "application/json; charset=UTF-8")
     @PreAuthorize("permitAll()")
     public ApiResponse<String> kakaoLogin(
-            @RequestBody LoginRequest code
+            @RequestBody LoginRequest code,
+            HttpServletResponse response
     ) throws JsonProcessingException {
         // code: 카카오 서버로부터 받은 인가 코드 Service 전달 후 인증 처리 및 JWT 반환
         return ApiResponse.ok(kakaoService.kakaoLogin(code));

--- a/src/main/java/com/wordwise/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/wordwise/domain/auth/controller/AuthController.java
@@ -32,11 +32,10 @@ public class AuthController {
     }
 
     // 카카오 인가코드 처리 API (로그인)
-    @PostMapping("/v1/auth/kakao/login")
+    @PostMapping(value = "/v1/auth/kakao/login", consumes = "application/json; charset=UTF-8")
     @PreAuthorize("permitAll()")
     public ApiResponse<String> kakaoLogin(
-            @RequestBody LoginRequest code,
-            HttpServletResponse response
+            @RequestBody LoginRequest code
     ) throws JsonProcessingException {
         // code: 카카오 서버로부터 받은 인가 코드 Service 전달 후 인증 처리 및 JWT 반환
         return ApiResponse.ok(kakaoService.kakaoLogin(code));

--- a/src/main/java/com/wordwise/domain/auth/request/LoginRequest.java
+++ b/src/main/java/com/wordwise/domain/auth/request/LoginRequest.java
@@ -1,9 +1,13 @@
 package com.wordwise.domain.auth.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class LoginRequest {
 
     @NotBlank(message="code 전달이 필요합니다.")


### PR DESCRIPTION
1. CORS Error 임시 처리
`@CrossOrigin(origins = "http://localhost:3000")`

2. 로그인 Front 연동
- 카카오 서버 인가코드랑 액세스 토큰 발급 Redirect URI 불일치 오류 해결